### PR TITLE
Add interactive Minesweeper web page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>扫雷小游戏</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="page">
+      <header class="page__header">
+        <h1>扫雷小游戏</h1>
+        <p>选择难度或自定义网格，在没有踩雷的情况下翻开所有安全格子！</p>
+      </header>
+
+      <section class="controls">
+        <div class="controls__group">
+          <label for="difficulty">难度：</label>
+          <select id="difficulty">
+            <option value="beginner">初级 (9×9 / 10颗雷)</option>
+            <option value="intermediate">中级 (16×16 / 40颗雷)</option>
+            <option value="expert">高级 (16×30 / 99颗雷)</option>
+            <option value="custom">自定义</option>
+          </select>
+        </div>
+        <form id="custom-form" class="controls__group controls__group--custom" hidden>
+          <label>行：<input type="number" id="rows" min="5" max="30" value="12" /></label>
+          <label>列：<input type="number" id="cols" min="5" max="30" value="12" /></label>
+          <label>雷数：<input type="number" id="mines" min="1" max="200" value="20" /></label>
+        </form>
+        <button id="restart" type="button">重新开始</button>
+      </section>
+
+      <section class="status">
+        <div>剩余雷数：<span id="mines-left">0</span></div>
+        <div>用时：<span id="timer">0</span>s</div>
+        <div id="message" role="status" aria-live="polite"></div>
+      </section>
+
+      <section class="board" id="board" role="grid" aria-label="扫雷棋盘"></section>
+
+      <section class="help">
+        <h2>玩法提示</h2>
+        <ul>
+          <li>左键或点按格子揭开；带数字的格子表示周围 8 个格子中的雷数。</li>
+          <li>右键或长按格子可以插旗标记雷；再次点击取消。</li>
+          <li>揭开所有非雷格子即可获胜，踩到雷则游戏失败。</li>
+        </ul>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,314 @@
+const difficulties = {
+  beginner: { rows: 9, cols: 9, mines: 10 },
+  intermediate: { rows: 16, cols: 16, mines: 40 },
+  expert: { rows: 16, cols: 30, mines: 99 },
+};
+
+const boardElement = document.getElementById("board");
+const difficultySelect = document.getElementById("difficulty");
+const customForm = document.getElementById("custom-form");
+const rowsInput = document.getElementById("rows");
+const colsInput = document.getElementById("cols");
+const minesInput = document.getElementById("mines");
+const restartButton = document.getElementById("restart");
+const minesLeftElement = document.getElementById("mines-left");
+const timerElement = document.getElementById("timer");
+const messageElement = document.getElementById("message");
+
+let state = {
+  rows: 0,
+  cols: 0,
+  mines: 0,
+  board: [],
+  revealedCount: 0,
+  flags: 0,
+  timerId: null,
+  secondsElapsed: 0,
+  started: false,
+  finished: false,
+};
+
+function createEmptyBoard(rows, cols) {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => ({
+      mine: false,
+      adjacent: 0,
+      revealed: false,
+      flagged: false,
+      element: null,
+    }))
+  );
+}
+
+function placeMines(board, mineCount, initialRow, initialCol) {
+  const positions = [];
+  board.forEach((row, r) =>
+    row.forEach((cell, c) => {
+      if (r === initialRow && c === initialCol) return;
+      positions.push([r, c]);
+    })
+  );
+
+  for (let i = positions.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [positions[i], positions[j]] = [positions[j], positions[i]];
+  }
+
+  positions.slice(0, mineCount).forEach(([r, c]) => {
+    board[r][c].mine = true;
+  });
+}
+
+function calculateAdjacents(board) {
+  const rows = board.length;
+  const cols = board[0].length;
+  const directions = [
+    [-1, -1],
+    [-1, 0],
+    [-1, 1],
+    [0, -1],
+    [0, 1],
+    [1, -1],
+    [1, 0],
+    [1, 1],
+  ];
+
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (board[r][c].mine) continue;
+      let count = 0;
+      for (const [dr, dc] of directions) {
+        const nr = r + dr;
+        const nc = c + dc;
+        if (nr >= 0 && nr < rows && nc >= 0 && nc < cols && board[nr][nc].mine) {
+          count++;
+        }
+      }
+      board[r][c].adjacent = count;
+    }
+  }
+}
+
+function resetTimer() {
+  if (state.timerId) {
+    clearInterval(state.timerId);
+  }
+  state.secondsElapsed = 0;
+  timerElement.textContent = "0";
+  state.timerId = null;
+}
+
+function startTimer() {
+  if (state.timerId) return;
+  state.timerId = setInterval(() => {
+    state.secondsElapsed += 1;
+    timerElement.textContent = state.secondsElapsed.toString();
+  }, 1000);
+}
+
+function updateMinesLeft() {
+  const remaining = Math.max(state.mines - state.flags, 0);
+  minesLeftElement.textContent = remaining.toString();
+}
+
+function showMessage(text, type = "") {
+  messageElement.textContent = text;
+  messageElement.dataset.type = type;
+  if (type === "win") {
+    messageElement.style.color = "var(--success)";
+  } else if (type === "lose") {
+    messageElement.style.color = "var(--accent)";
+  } else {
+    messageElement.style.color = "inherit";
+  }
+}
+
+function revealCell(row, col) {
+  const cell = state.board[row][col];
+  if (cell.revealed || cell.flagged || state.finished) return;
+
+  if (!state.started) {
+    state.started = true;
+    placeMines(state.board, state.mines, row, col);
+    calculateAdjacents(state.board);
+    startTimer();
+  }
+
+  cell.revealed = true;
+  cell.element.classList.add("revealed");
+  state.revealedCount += 1;
+
+  if (cell.mine) {
+    cell.element.classList.add("mine");
+    endGame(false);
+    return;
+  }
+
+  if (cell.adjacent > 0) {
+    cell.element.dataset.value = cell.adjacent;
+    cell.element.textContent = cell.adjacent;
+  } else {
+    floodReveal(row, col);
+  }
+
+  checkWinCondition();
+}
+
+function floodReveal(row, col) {
+  const queue = [[row, col]];
+  const rows = state.rows;
+  const cols = state.cols;
+  const directions = [
+    [-1, -1],
+    [-1, 0],
+    [-1, 1],
+    [0, -1],
+    [0, 1],
+    [1, -1],
+    [1, 0],
+    [1, 1],
+  ];
+
+  while (queue.length) {
+    const [r, c] = queue.shift();
+    const cell = state.board[r][c];
+
+    if (cell.adjacent > 0) {
+      cell.element.dataset.value = cell.adjacent;
+      cell.element.textContent = cell.adjacent;
+      continue;
+    }
+
+    for (const [dr, dc] of directions) {
+      const nr = r + dr;
+      const nc = c + dc;
+      if (nr < 0 || nr >= rows || nc < 0 || nc >= cols) continue;
+      const neighbor = state.board[nr][nc];
+      if (neighbor.revealed || neighbor.flagged) continue;
+      neighbor.revealed = true;
+      neighbor.element.classList.add("revealed");
+      state.revealedCount += 1;
+      if (neighbor.adjacent === 0) {
+        queue.push([nr, nc]);
+      } else {
+        neighbor.element.dataset.value = neighbor.adjacent;
+        neighbor.element.textContent = neighbor.adjacent;
+      }
+    }
+  }
+}
+
+function toggleFlag(row, col) {
+  const cell = state.board[row][col];
+  if (cell.revealed || state.finished) return;
+
+  cell.flagged = !cell.flagged;
+  cell.element.classList.toggle("flagged", cell.flagged);
+  state.flags += cell.flagged ? 1 : -1;
+  updateMinesLeft();
+}
+
+function endGame(win) {
+  state.finished = true;
+  clearInterval(state.timerId);
+  state.timerId = null;
+  showMessage(win ? "恭喜过关！" : "踩到雷啦，再试一次吧~", win ? "win" : "lose");
+
+  if (!win) {
+    state.board.forEach((row) =>
+      row.forEach((cell) => {
+        if (cell.mine) {
+          cell.element.classList.add("mine", "revealed");
+        }
+      })
+    );
+  }
+}
+
+function checkWinCondition() {
+  const totalSafe = state.rows * state.cols - state.mines;
+  if (state.revealedCount >= totalSafe && !state.finished) {
+    endGame(true);
+  }
+}
+
+function buildBoard() {
+  boardElement.innerHTML = "";
+  boardElement.style.gridTemplateColumns = `repeat(${state.cols}, var(--cell-size))`;
+  boardElement.style.gridTemplateRows = `repeat(${state.rows}, var(--cell-size))`;
+
+  for (let r = 0; r < state.rows; r++) {
+    for (let c = 0; c < state.cols; c++) {
+      const cellElement = document.createElement("button");
+      cellElement.type = "button";
+      cellElement.className = "cell";
+      cellElement.setAttribute("role", "gridcell");
+      cellElement.setAttribute("aria-label", `第${r + 1}行第${c + 1}列`);
+
+      cellElement.addEventListener("click", () => revealCell(r, c));
+      cellElement.addEventListener("contextmenu", (event) => {
+        event.preventDefault();
+        toggleFlag(r, c);
+      });
+      cellElement.addEventListener("pointerdown", (event) => {
+        if (event.pointerType === "touch") {
+          event.preventDefault();
+          toggleFlag(r, c);
+        }
+      });
+
+      state.board[r][c].element = cellElement;
+      boardElement.appendChild(cellElement);
+    }
+  }
+}
+
+function initGame() {
+  const selected = difficultySelect.value;
+  let rows;
+  let cols;
+  let mines;
+
+  if (selected === "custom") {
+    customForm.hidden = false;
+    rows = Number(rowsInput.value);
+    cols = Number(colsInput.value);
+    mines = Number(minesInput.value);
+    const maxMines = rows * cols - 1;
+    if (mines > maxMines) {
+      mines = maxMines;
+      minesInput.value = String(maxMines);
+    }
+  } else {
+    customForm.hidden = true;
+    ({ rows, cols, mines } = difficulties[selected]);
+  }
+
+  state = {
+    rows,
+    cols,
+    mines,
+    board: createEmptyBoard(rows, cols),
+    revealedCount: 0,
+    flags: 0,
+    timerId: null,
+    secondsElapsed: 0,
+    started: false,
+    finished: false,
+  };
+
+  updateMinesLeft();
+  resetTimer();
+  showMessage("点击任意格子开始游戏！");
+  buildBoard();
+}
+
+restartButton.addEventListener("click", initGame);
+difficultySelect.addEventListener("change", initGame);
+customForm.addEventListener("input", () => {
+  if (difficultySelect.value === "custom") {
+    initGame();
+  }
+});
+
+document.addEventListener("DOMContentLoaded", initGame);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,178 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f2f5f8;
+  --panel: rgba(255, 255, 255, 0.85);
+  --text: #253046;
+  --accent: #ff595e;
+  --success: #0ba360;
+  --grid-border: #b0bec5;
+  --cell-size: clamp(2.2rem, 5vw, 3rem);
+  font-family: 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(160deg, #b8c6db, #f5f7fa);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem 4rem;
+}
+
+.page {
+  max-width: 60rem;
+  width: 100%;
+  background: var(--panel);
+  backdrop-filter: blur(10px);
+  border-radius: 1.5rem;
+  box-shadow: 0 1.5rem 3rem rgba(37, 48, 70, 0.2);
+  padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.page__header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 5vw, 2.6rem);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
+.controls__group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+}
+
+.controls__group input,
+.controls__group select,
+.controls button {
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(37, 48, 70, 0.2);
+  font: inherit;
+  background: #ffffff;
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.controls button {
+  cursor: pointer;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  box-shadow: 0 0.3rem 0.6rem rgba(255, 89, 94, 0.3);
+}
+
+.controls button:hover {
+  filter: brightness(1.05);
+}
+
+.controls__group--custom label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+}
+
+.status {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+  font-weight: 600;
+}
+
+#message {
+  min-height: 1.5rem;
+}
+
+.board {
+  display: grid;
+  justify-content: center;
+  gap: 2px;
+  background: var(--grid-border);
+  padding: 6px;
+  border-radius: 0.8rem;
+  box-shadow: inset 0 0 0 1px rgba(37, 48, 70, 0.1);
+}
+
+.cell {
+  width: var(--cell-size);
+  height: var(--cell-size);
+  display: grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.9);
+  font-weight: 700;
+  font-size: calc(var(--cell-size) * 0.45);
+  border-radius: 0.4rem;
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+  transition: transform 0.1s ease, background 0.2s ease;
+}
+
+.cell:hover {
+  transform: translateY(-1px);
+}
+
+.cell.revealed {
+  background: #eceff1;
+  cursor: default;
+  box-shadow: inset 0 2px 4px rgba(37, 48, 70, 0.1);
+}
+
+.cell.mine.revealed {
+  background: #ffe8ea;
+}
+
+.cell.flagged::after {
+  content: '\1F6A9';
+  font-size: calc(var(--cell-size) * 0.5);
+}
+
+.cell.mine.revealed::before {
+  content: '\1F4A3';
+  font-size: calc(var(--cell-size) * 0.6);
+}
+
+.cell[data-value="1"] { color: #1e88e5; }
+.cell[data-value="2"] { color: #43a047; }
+.cell[data-value="3"] { color: #f4511e; }
+.cell[data-value="4"] { color: #8e24aa; }
+.cell[data-value="5"] { color: #d81b60; }
+.cell[data-value="6"] { color: #00acc1; }
+.cell[data-value="7"] { color: #5d4037; }
+.cell[data-value="8"] { color: #212121; }
+
+.help ul {
+  padding-left: 1.2rem;
+  margin: 0.5rem 0 0;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1rem;
+  }
+
+  .page {
+    padding: 1.5rem;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .controls__group,
+  .controls button {
+    width: 100%;
+    justify-content: space-between;
+  }
+}


### PR DESCRIPTION
## Summary
- add a responsive HTML layout for a Minesweeper game with difficulty selection and status display
- create styling for the game board, controls, and responsive layout
- implement JavaScript logic for mine placement, cell revealing, flagging, and win/loss handling

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dd3095f688832bb9636a243a9a95b9